### PR TITLE
Remove 16kHz only warning and assertion

### DIFF
--- a/vad_transcriber/audioTranscript_cmd.py
+++ b/vad_transcriber/audioTranscript_cmd.py
@@ -47,7 +47,8 @@ def main(args):
 
         # Run VAD on the input file
         waveFile = args.audio
-        segments, sample_rate, audio_length = wavTranscriber.vad_segment_generator(waveFile, args.aggressive)
+        segments, sample_rate, audio_length = wavTranscriber.vad_segment_generator(waveFile, args.aggressive,
+                                                                                   model_sample_rate=model_retval[3])
         f = open(waveFile.rstrip(".wav") + ".txt", 'w')
         logging.debug("Saving Transcript @: %s" % waveFile.rstrip(".wav") + ".txt")
 

--- a/vad_transcriber/audioTranscript_gui.py
+++ b/vad_transcriber/audioTranscript_gui.py
@@ -352,7 +352,8 @@ class App(QMainWindow):
         inference_time = 0.0
 
         # Run VAD on the input file
-        segments, sample_rate, audio_length = wavTranscriber.vad_segment_generator(waveFile, 1)
+        segments, sample_rate, audio_length = wavTranscriber.vad_segment_generator(waveFile, 1,
+                                                                                   model_sample_rate=self.model[3])
         f = open(waveFile.rstrip(".wav") + ".txt", 'w')
         logging.debug("Saving Transcript @: %s" % waveFile.rstrip(".wav") + ".txt")
 

--- a/vad_transcriber/wavTranscriber.py
+++ b/vad_transcriber/wavTranscriber.py
@@ -29,7 +29,10 @@ def load_model(models, lm, trie):
     lm_load_end = timer() - lm_load_start
     logging.debug('Loaded language model in %0.3fs.' % (lm_load_end))
 
-    return [ds, model_load_end, lm_load_end]
+    sample_rate = ds.sampleRate()
+    logging.debug('Loaded model sample rate: %dHz.' % (sample_rate))
+
+    return [ds, model_load_end, lm_load_end, sample_rate]
 
 '''
 Run Inference on input audio file
@@ -85,9 +88,11 @@ Returns tuple of
     audio_length: Duraton of the input audio file
 
 '''
-def vad_segment_generator(wavFile, aggressiveness):
+def vad_segment_generator(wavFile, aggressiveness, model_sample_rate):
     logging.debug("Caught the wav file @: %s" % (wavFile))
     audio, sample_rate, audio_length = wavSplit.read_wave(wavFile)
+    assert sample_rate == model_sample_rate, \
+        "Audio sample rate must match sample rate of used model: {}Hz".format(model_sample_rate)
     vad = webrtcvad.Vad(int(aggressiveness))
     frames = wavSplit.frame_generator(30, audio, sample_rate)
     frames = list(frames)

--- a/vad_transcriber/wavTranscriber.py
+++ b/vad_transcriber/wavTranscriber.py
@@ -88,7 +88,6 @@ Returns tuple of
 def vad_segment_generator(wavFile, aggressiveness):
     logging.debug("Caught the wav file @: %s" % (wavFile))
     audio, sample_rate, audio_length = wavSplit.read_wave(wavFile)
-    assert sample_rate == 16000, "Only 16000Hz input WAV files are supported for now!"
     vad = webrtcvad.Vad(int(aggressiveness))
     frames = wavSplit.frame_generator(30, audio, sample_rate)
     frames = list(frames)

--- a/vad_transcriber/wavTranscription.md
+++ b/vad_transcriber/wavTranscription.md
@@ -73,10 +73,6 @@ sample_rec.wav                 13.710               20.797               5.593  
 
 ```
 
-**Note:** Only `wav` files with a 16kHz sample rate are supported for now, you can convert your files to the appropriate format with ffmpeg if available on your system.
-
-    ffmpeg -i infile.mp3  -ar 16000 -ac 1  outfile.wav
-
 ### 2. Minimalistic GUI
 
 The GUI tool does the same job as the CLI tool. The VAD is fixed at an aggressiveness of 1.


### PR DESCRIPTION
DeepSpeech supports other frequencies than 16kHz now, there are tests for it: mozilla/DeepSpeech#2640
frame_generator provides proper frames with sample_rate inferred from audio file so it's not an issue