### PR TITLE
add warning to electron example if the audio path doesn't exist

### DIFF
--- a/electron/Readme.md
+++ b/electron/Readme.md
@@ -14,8 +14,8 @@ npm run rebuild
 Download and extract audio files to `/public` directory
 
 ```
-wget https://github.com/mozilla/DeepSpeech/releases/download/v0.7.0/audio-0.7.0.tar.gz
-tar xfvz audio-0.7.0.tar.gz -C ./public/
+wget https://github.com/mozilla/DeepSpeech/releases/download/v0.8.0/audio-0.8.0.tar.gz
+tar xfvz audio-0.8.0.tar.gz -C ./public/
 ```
 
 (Optional) Download or softlink DeepSpeech 0.8.0 model files to the root of the project:

--- a/electron/public/create-window.js
+++ b/electron/public/create-window.js
@@ -68,11 +68,20 @@ function createWindow(model) {
 		return new Promise(function (resolve, reject) {
 			try {
 				let audioPath = path.resolve(__dirname, 'audio');
-				fs.readdir(audioPath, function (err, files) {
-					files = files.filter(function (file) {
-						return file.endsWith('.wav');
-					});
-					resolve(files);
+				fs.exists(audioPath, function(exists) {
+					if (exists) {
+						fs.readdir(audioPath, function (err, files) {
+							files = files.filter(function (file) {
+								return file.endsWith('.wav');
+							});
+							resolve(files);
+						});
+					}
+					else {
+						console.log('audio files path does not exist: ', audioPath);
+						console.log('See Readme.md');
+						process.exit();
+					}
 				});
 			} catch (e) {
 				reject(e.toString())


### PR DESCRIPTION
If the audio.tar.gz file wasn't extracted to public/audio then abort and print a warning message.