### PR TITLE
Send output through system keyboard to enable voice typing in any application

### DIFF
--- a/mic_vad_streaming/README.rst
+++ b/mic_vad_streaming/README.rst
@@ -56,3 +56,5 @@ Usage
                            pyaudio.PyAudio.get_device_info_by_index(). If not
                            provided, falls back to PyAudio.get_default_device().
      -r RATE, --rate RATE  Input device sample rate. Default: 16000. Your device
+                           may require 44100.
+     -k, --keyboard        Type output through system keyboards

--- a/mic_vad_streaming/mic_vad_streaming.py
+++ b/mic_vad_streaming/mic_vad_streaming.py
@@ -193,6 +193,9 @@ def main(ARGS):
                 wav_data = bytearray()
             text = stream_context.finishStream()
             print("Recognized: %s" % text)
+            if ARGS.keyboard:
+                from pyautogui import typewrite
+                typewrite(text)
             stream_context = model.createStream()
 
 if __name__ == '__main__':
@@ -218,7 +221,8 @@ if __name__ == '__main__':
                         help="Device input index (Int) as listed by pyaudio.PyAudio.get_device_info_by_index(). If not provided, falls back to PyAudio.get_default_device().")
     parser.add_argument('-r', '--rate', type=int, default=DEFAULT_SAMPLE_RATE,
                         help=f"Input device sample rate. Default: {DEFAULT_SAMPLE_RATE}. Your device may require 44100.")
-
+    parser.add_argument('-k', '--keyboard', action='store_true', 
+                        help="Type output through system keyboard")
     ARGS = parser.parse_args()
     if ARGS.savewav: os.makedirs(ARGS.savewav, exist_ok=True)
     main(ARGS)

--- a/mic_vad_streaming/requirements.txt
+++ b/mic_vad_streaming/requirements.txt
@@ -4,3 +4,4 @@ webrtcvad~=2.0.10
 halo~=0.0.18
 numpy>=1.15.1
 scipy>=1.1.0
+pyautogui~=0.9.52


### PR DESCRIPTION
I thought this was a really useful feature, and it only takes a couple of lines of code.

Using the existing streaming example, you can now "type" by speaking in any application on your computer.