### PR TITLE
fixed setting microphone as local var instead of global as intended

### DIFF
--- a/nodejs_mic_vad_streaming/start.js
+++ b/nodejs_mic_vad_streaming/start.js
@@ -201,7 +201,7 @@ function startMicrophone(callback) {
 	
 	createStream();
 	
-	var microphone = mic({
+	microphone = mic({
 		rate: '16000',
 		channels: '1',
 		debug: false,


### PR DESCRIPTION
Example: nodejs_mic_vad_streaming

### The Problem
When the function `stopMicrophone()` was called microphone was undefined.

### The Solution
In the `startMicrophone()` it checks if the microphone is not undefined. If it is undefined it sets a local variable named microphone instead of using the global defined `let microphone`, which is defined in Line 197.
That is why I just removed the `var` keyword to use the global microphone variable instead of instantiating a local one.

This is my first PR ever. So if there is anything wrong I am sorry, please let me know :)